### PR TITLE
Enable Dependabot Linear Alerts with Gigsbot

### DIFF
--- a/.github/gigsbot.yml
+++ b/.github/gigsbot.yml
@@ -1,0 +1,3 @@
+linear_dependabot_alerts:
+  team: Connect
+  labels: [Security]


### PR DESCRIPTION
- Adds `linear_dependabot_alerts` gigsbot integration, which creates a Linear ticket for a Dependabot alert
- Sends alerts to the Connect Team board