### PR TITLE
Strip dashes from accountPin for Verizon donors

### DIFF
--- a/lib/PortingEmbed/StepCarrierDetailsForm.tsx
+++ b/lib/PortingEmbed/StepCarrierDetailsForm.tsx
@@ -20,6 +20,27 @@ type Props = {
   onSubmit: (data: Partial<StepCarrierDetailsFormData>) => unknown
 }
 
+const normalizeAccountPin = (
+  accountPin: string | undefined,
+  donorProviderName: string | undefined,
+) => {
+  // If accountPin is `undefined`, keep it that way
+  if (!accountPin) {
+    return accountPin
+  }
+
+  // If the donor provider is Verizon, we want to strip eventual dashes.
+  // Verizon displays their account PINs to users with dashes when they retreive it,
+  // but expects the PIN without dashes.
+  // In order to prevent failed portings, we remove them here.
+  if (donorProviderName === 'Verizon') {
+    return accountPin.replaceAll('-', '').trim()
+  }
+
+  // In all other cases, trim the accountPin
+  return accountPin.trim()
+}
+
 export function StepCarrierDetailsForm({
   porting,
   onValidationChange,
@@ -77,8 +98,11 @@ export function StepCarrierDetailsForm({
           return
         }
 
-        // Trim the account pin if there is one
-        data.accountPin = data.accountPin?.trim()
+        // Normalize the accountPin
+        data.accountPin = normalizeAccountPin(
+          data.accountPin,
+          porting.donorProvider?.name,
+        )
 
         const sanitizedData = sanitizeSubmitData(data)
         return onSubmit(sanitizedData)

--- a/lib/PortingEmbed/StepCarrierDetailsForm.tsx
+++ b/lib/PortingEmbed/StepCarrierDetailsForm.tsx
@@ -9,17 +9,6 @@ import { EmbedFieldLabel } from './EmbedFieldLabel'
 import { defaultFormId, useEmbedOptions } from './Options'
 import { sanitizeSubmitData } from './sanitizeSubmitData'
 
-export type StepCarrierDetailsFormData = {
-  accountNumber?: string
-  accountPin?: string
-}
-
-type Props = {
-  porting: Porting
-  onValidationChange?: (event: { isValid: boolean }) => unknown
-  onSubmit: (data: Partial<StepCarrierDetailsFormData>) => unknown
-}
-
 const normalizeAccountPin = (
   accountPin: string | undefined,
   donorProviderName: string | undefined,
@@ -39,6 +28,17 @@ const normalizeAccountPin = (
 
   // In all other cases, trim the accountPin
   return accountPin.trim()
+}
+
+export type StepCarrierDetailsFormData = {
+  accountNumber?: string
+  accountPin?: string
+}
+
+type Props = {
+  porting: Porting
+  onValidationChange?: (event: { isValid: boolean }) => unknown
+  onSubmit: (data: Partial<StepCarrierDetailsFormData>) => unknown
 }
 
 export function StepCarrierDetailsForm({

--- a/lib/PortingEmbed/__tests__/PortingForm.test.tsx
+++ b/lib/PortingEmbed/__tests__/PortingForm.test.tsx
@@ -62,12 +62,42 @@ describe('carrier details', () => {
     )
 
     await user.type(screen.getByLabelText('Account Number'), '123456')
-    await user.type(screen.getByLabelText('Account PIN'), '1234')
+    await user.type(screen.getByLabelText('Account PIN'), '123-456')
     await user.click(screen.getByRole('button', { name: 'Submit' }))
 
     expect(submit).toHaveBeenCalledWith({
       accountNumber: '123456',
-      accountPin: '1234',
+      accountPin: '123-456',
+    })
+  })
+
+  it('strips dashes from accountPin if porting donor provider is Verizon', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <PortingForm
+        porting={{
+          ...porting,
+          donorProvider: {
+            object: 'serviceProvider',
+            id: 'svp_0T6kd2kx4eNwH7Thi9tAl5',
+            name: 'Verizon',
+            recipientProviders: [],
+          },
+        }}
+        onValidationChange={validationChange}
+        onSubmit={submit}
+      />,
+      { wrapper },
+    )
+
+    await user.type(screen.getByLabelText('Account Number'), '123456')
+    await user.type(screen.getByLabelText('Account PIN'), '123-456')
+    await user.click(screen.getByRole('button', { name: 'Submit' }))
+
+    expect(submit).toHaveBeenCalledWith({
+      accountNumber: '123456',
+      accountPin: '123456',
     })
   })
 })

--- a/lib/PortingEmbed/__tests__/PortingForm.test.tsx
+++ b/lib/PortingEmbed/__tests__/PortingForm.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/preact'
 import userEvent from '@testing-library/user-event'
 
 import { portingFactory } from '@/testing/factories/porting'
+import { serviceProviderFactory } from '@/testing/factories/serviceProvider'
 
 import { PortingForm } from '../PortingForm'
 
@@ -73,18 +74,14 @@ describe('carrier details', () => {
 
   it('strips dashes from accountPin if porting donor provider is Verizon', async () => {
     const user = userEvent.setup()
+    const donorProvider = serviceProviderFactory.build({ name: 'Verizon' })
+    const porting = portingFactory
+      .associations({ donorProvider })
+      .build({ required: ['accountNumber', 'accountPin'] })
 
     render(
       <PortingForm
-        porting={{
-          ...porting,
-          donorProvider: {
-            object: 'serviceProvider',
-            id: 'svp_0T6kd2kx4eNwH7Thi9tAl5',
-            name: 'Verizon',
-            recipientProviders: [],
-          },
-        }}
+        porting={porting}
         onValidationChange={validationChange}
         onSubmit={submit}
       />,

--- a/lib/PortingEmbed/__tests__/PortingForm.test.tsx
+++ b/lib/PortingEmbed/__tests__/PortingForm.test.tsx
@@ -97,6 +97,31 @@ describe('carrier details', () => {
       accountPin: '123456',
     })
   })
+
+  it('does not strip dashes from accountPin for donor provider other than Verizon', async () => {
+    const user = userEvent.setup()
+    const porting = portingFactory.build({
+      required: ['accountNumber', 'accountPin'],
+    })
+
+    render(
+      <PortingForm
+        porting={porting}
+        onValidationChange={validationChange}
+        onSubmit={submit}
+      />,
+      { wrapper },
+    )
+
+    await user.type(screen.getByLabelText('Account Number'), '123456')
+    await user.type(screen.getByLabelText('Account PIN'), '123-456')
+    await user.click(screen.getByRole('button', { name: 'Submit' }))
+
+    expect(submit).toHaveBeenCalledWith({
+      accountNumber: '123456',
+      accountPin: '123-456',
+    })
+  })
 })
 
 describe('holder details', () => {

--- a/lib/PortingEmbed/__tests__/StepCarrierDetailsForm.test.tsx
+++ b/lib/PortingEmbed/__tests__/StepCarrierDetailsForm.test.tsx
@@ -171,6 +171,33 @@ describe('account pin', () => {
     expect(submit).toHaveBeenCalledWith({ accountPin: '1234 56' })
   })
 
+  it('removes dashes when submitting for Verizon donor provider', async () => {
+    const porting = portingFactory.build({ required: ['accountPin'] })
+    const user = userEvent.setup()
+    const submit = vi.fn()
+    render(
+      <StepCarrierDetailsForm
+        porting={{
+          ...porting,
+          donorProvider: {
+            object: 'serviceProvider',
+            id: 'svp_0T6kd2kx4eNwH7Thi9tAl5',
+            name: 'Verizon',
+            recipientProviders: [],
+          },
+        }}
+        onSubmit={submit}
+      />,
+      {
+        wrapper,
+      },
+    )
+
+    await user.type(screen.getByLabelText('Account PIN'), '  123-456  ')
+    await user.click(screen.getByRole('button'))
+    expect(submit).toHaveBeenCalledWith({ accountPin: '123456' })
+  })
+
   it('shows an error on submit when left empty and not present', async () => {
     const porting = portingFactory.build({ required: ['accountPin'] })
     const user = userEvent.setup()

--- a/lib/PortingEmbed/__tests__/StepCarrierDetailsForm.test.tsx
+++ b/lib/PortingEmbed/__tests__/StepCarrierDetailsForm.test.tsx
@@ -188,6 +188,19 @@ describe('account pin', () => {
     expect(submit).toHaveBeenCalledWith({ accountPin: '123456' })
   })
 
+  it('does not remove dashes for donor providers other than Veriozon', async () => {
+    const porting = portingFactory.build({ required: ['accountPin'] })
+    const user = userEvent.setup()
+    const submit = vi.fn()
+    render(<StepCarrierDetailsForm porting={porting} onSubmit={submit} />, {
+      wrapper,
+    })
+
+    await user.type(screen.getByLabelText('Account PIN'), '  123-456  ')
+    await user.click(screen.getByRole('button'))
+    expect(submit).toHaveBeenCalledWith({ accountPin: '123-456' })
+  })
+
   it('shows an error on submit when left empty and not present', async () => {
     const porting = portingFactory.build({ required: ['accountPin'] })
     const user = userEvent.setup()

--- a/lib/PortingEmbed/__tests__/StepCarrierDetailsForm.test.tsx
+++ b/lib/PortingEmbed/__tests__/StepCarrierDetailsForm.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/preact'
 import userEvent from '@testing-library/user-event'
 
 import { portingFactory } from '@/testing/factories/porting'
+import { serviceProviderFactory } from '@/testing/factories/serviceProvider'
 
 import { OptionsContext } from '../Options'
 import { StepCarrierDetailsForm } from '../StepCarrierDetailsForm'
@@ -172,26 +173,15 @@ describe('account pin', () => {
   })
 
   it('removes dashes when submitting for Verizon donor provider', async () => {
-    const porting = portingFactory.build({ required: ['accountPin'] })
+    const donorProvider = serviceProviderFactory.build({ name: 'Verizon' })
+    const porting = portingFactory
+      .associations({ donorProvider })
+      .build({ required: ['accountPin'] })
     const user = userEvent.setup()
     const submit = vi.fn()
-    render(
-      <StepCarrierDetailsForm
-        porting={{
-          ...porting,
-          donorProvider: {
-            object: 'serviceProvider',
-            id: 'svp_0T6kd2kx4eNwH7Thi9tAl5',
-            name: 'Verizon',
-            recipientProviders: [],
-          },
-        }}
-        onSubmit={submit}
-      />,
-      {
-        wrapper,
-      },
-    )
+    render(<StepCarrierDetailsForm porting={porting} onSubmit={submit} />, {
+      wrapper,
+    })
 
     await user.type(screen.getByLabelText('Account PIN'), '  123-456  ')
     await user.click(screen.getByRole('button'))


### PR DESCRIPTION
### Rationale

We have recently learned that Verizon will display their users account PINs with dashes (e.g. 123-456) for better readability, but actually requires the PIN to be sent without dashes for port outs.
Naturally, this cause users to copy the PIN in the format provided by Verizon, causing failed portings.

We have adapted [Connect](https://gigs.com/connect) to automatically strip dashes from the accountPin field in the porting form for Verizon portings and decided to backport this functionality to our other products as well.

### Changes
`<StepCarrierDetailsForm />` defines a new function (outside of the component), `normalizeAccountPin`, which handles the removal of dashes in case the `donorProvider` is "Verizon". The trimming that was done in `onSubmit` before has been moved into this function as well.