### PR TITLE
Bump version to 0.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "author": "Gigs (https://gigs.com)",
   "repository": "gigs/embeds-js",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",


### PR DESCRIPTION
This is done in preparation of a new release. This release will contain no code changes, but release 0.1.2 currently does not have a clean state (the npm release points to a commit that contains a `package.json` with version `0.1.1`).

After this PR is merged and thus the version in the `package.json` is `0.1.3`, I will trigger a new release from main which should then have a clean version state again.